### PR TITLE
Remove duplicated ThemeProvider component

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,9 +1,0 @@
-"use client"
-
-import * as React from "react"
-import { ThemeProvider as NextThemesProvider } from "next-themes"
-import { type ThemeProviderProps } from "next-themes/dist/types"
-
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
-}


### PR DESCRIPTION
Hey @iluxonchik , it seems that the same component was accidentally copied to the root of the project. I see that it is not used. If this is intentional and has some external use, you can close the PR, thanks