### PR TITLE
Add success feedback and redirect for wallet authentication

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 import {
@@ -76,6 +76,8 @@ function AuthenticationOptions() {
 	const [showDiscordDialog, setShowDiscordDialog] = useState(false)
 	const [showWalletDialog, setShowWalletDialog] = useState(false)
 	const { state } = useWallet()
+	const router = useRouter()
+	const [walletAuthSuccess, setWalletAuthSuccess] = useState(false)
 
 	const handleWalletAuth = () => {
 		if (state.wallet) {
@@ -97,6 +99,48 @@ function AuthenticationOptions() {
 			setShowWalletDialog(true)
 		}
 	}, [state.wallet, showWalletConnector])
+
+	// Add effect to redirect after successful wallet authentication
+	useEffect(() => {
+		if (walletAuthSuccess) {
+			const timer = setTimeout(() => {
+				router.push('/')
+			}, 2000)
+
+			return () => clearTimeout(timer)
+		}
+	}, [walletAuthSuccess, router])
+
+	// Handler for when wallet auth is successful
+	const handleWalletAuthSuccess = useCallback(() => {
+		setShowWalletDialog(false)
+		setWalletAuthSuccess(true)
+	}, [])
+
+	if (walletAuthSuccess) {
+		return (
+			<Card className="w-full max-w-md">
+				<CardHeader>
+					<CardTitle>Authentication Successful</CardTitle>
+					<CardDescription>
+						Redirecting you to your destination...
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Alert
+						variant="default"
+						className="border-green-200 bg-green-50 text-green-800"
+					>
+						<CheckCircle2 className="h-4 w-4 text-green-600" />
+						<AlertTitle>Success!</AlertTitle>
+						<AlertDescription className="text-green-700">
+							Authentication with wallet completed successfully.
+						</AlertDescription>
+					</Alert>
+				</CardContent>
+			</Card>
+		)
+	}
 
 	return (
 		<Card className="w-full max-w-md">
@@ -171,6 +215,7 @@ function AuthenticationOptions() {
 				<WalletAuthDialog
 					open={showWalletDialog}
 					onOpenChange={setShowWalletDialog}
+					onSuccess={handleWalletAuthSuccess}
 				/>
 			</CardContent>
 		</Card>

--- a/src/components/web3/WalletAuthDialog.tsx
+++ b/src/components/web3/WalletAuthDialog.tsx
@@ -24,6 +24,7 @@ import { useAuth } from '@/contexts/AuthContext'
 interface WalletAuthDialogProps {
 	open: boolean
 	onOpenChange: (open: boolean) => void
+	onSuccess?: () => void
 }
 
 interface LinkingDialogProps {
@@ -118,6 +119,7 @@ function LinkingDialog({
 export function WalletAuthDialog({
 	open,
 	onOpenChange,
+	onSuccess,
 }: WalletAuthDialogProps) {
 	const { state } = useWallet()
 	const { toast } = useToast()
@@ -182,10 +184,13 @@ export function WalletAuthDialog({
 			} else {
 				toast({
 					title: 'Successfully authenticated',
-					description:
-						'You are now logged in with your wallet. Redirecting you to your destination...',
+					description: 'You are now logged in with your wallet.',
 				})
 				onOpenChange(false)
+				// Call onSuccess if provided
+				if (onSuccess) {
+					onSuccess()
+				}
 			}
 		} catch (error) {
 			toast({
@@ -245,10 +250,18 @@ export function WalletAuthDialog({
 							description: 'Your accounts have been successfully linked',
 						})
 						onOpenChange(false)
+						// Call onSuccess if provided
+						if (onSuccess) {
+							onSuccess()
+						}
 					}}
 					onCancel={() => {
 						setShowLinkingDialog(false)
 						onOpenChange(false)
+						// Call onSuccess if we still have successful auth
+						if (onSuccess && authTokens?.walletToken) {
+							onSuccess()
+						}
 					}}
 				/>
 			)}

--- a/src/contexts/WalletContext.tsx
+++ b/src/contexts/WalletContext.tsx
@@ -330,6 +330,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 			<WalletAuthDialog
 				open={showAuthDialog}
 				onOpenChange={setShowAuthDialog}
+				onSuccess={undefined}
 			/>
 		</WalletContext.Provider>
 	)


### PR DESCRIPTION
Add Success Feedback for Wallet Authentication

Added a success feedback screen and automatic redirection after wallet authentication. Previously, users only received a toast notification, but now they get a clear visual confirmation screen with a success message before being redirected to the homepage.

Key changes:

- Added wallet authentication success state and UI in auth/page.tsx
- Modified WalletAuthDialog to accept and trigger an onSuccess callback
- Updated handling for account linking scenarios
- Set 2-second delay before redirecting to allow users to see the confirmation

**This change creates consistency with the token authentication flow which already had a success screen.**